### PR TITLE
change some codes for successful build and Loading binaray file ( *.cppbin ) in clExport x64.

### DIFF
--- a/inc/clcpp/clcpp.h
+++ b/inc/clcpp/clcpp.h
@@ -196,7 +196,7 @@ namespace clcpp
 //
 // Placement new for the PtrWrapper logic specified above, which required matching delete
 //
-inline void* operator new(clcpp::size_type size, const clcpp::internal::PtrWrapper& p)
+inline void* operator new(size_t size, const clcpp::internal::PtrWrapper& p)
 {
     return (void*)&p;
 }

--- a/src/clReflectCore/Logging.cpp
+++ b/src/clReflectCore/Logging.cpp
@@ -188,26 +188,14 @@ namespace
 
 	unsigned int Log2(unsigned int v)
 	{
-#ifdef _MSC_VER
-		// Branchless, taking into account v=0, x86 specific
-		_asm
-		{
-			mov eax, v
-			mov ebx, -1
-			bsr eax, eax
-			cmovz eax, ebx
-			mov v, eax
-		}
-#else
-        // we provides a c implementation here since we may compile on llvm
         if (v == 0)
         {
             v = -1;
-        } else
-        {
-            v = sizeof(unsigned int) * 8 - 1 - __builtin_clz(v);
         }
-#endif  // _MSC_VER
+        else
+        {
+            v = sizeof(unsigned int) * 8 - 1 - __lzcnt(v);
+        }
 		return v;
 	}
 }

--- a/src/clReflectExport/CppExport.cpp
+++ b/src/clReflectExport/CppExport.cpp
@@ -15,7 +15,7 @@
 //
 
 #include "CppExport.h"
-#include "PtrRelocator.h"
+
 
 #include <clReflectCore/Database.h>
 #include <clReflectCore/FileUtils.h>
@@ -23,7 +23,7 @@
 
 #include <clcpp/clcpp.h>
 #include <clcpp/clcpp_internal.h>
-
+#include "PtrRelocator.h"
 #include <algorithm>
 #include <string.h>
 
@@ -1443,16 +1443,16 @@ void SaveCppExport(CppExport& cppexp, const char* filename)
     header.nb_ptr_relocations = relocations.size();
     header.data_size = cppexp.allocator.GetAllocatedSize();
     fwrite(&header, sizeof(header), 1, fp);
-
+    
     // Write the complete memory map
     fwrite(cppexp.allocator.GetData(), cppexp.allocator.GetAllocatedSize(), 1, fp);
 
     // Write the stride of each schema and the location of their pointers
-    size_t ptrs_offset = 0;
+    clcpp::pointer_type ptrs_offset = 0;
     for (size_t i = 0; i < schemas.size(); i++)
     {
         const PtrSchema& s = *schemas[i];
-        size_t nb_ptrs = s.ptr_offsets.size();
+        decltype(s.ptr_offsets)::size_type nb_ptrs = s.ptr_offsets.size();
         fwrite(&s.stride, sizeof(s.stride), 1, fp);
         fwrite(&ptrs_offset, sizeof(ptrs_offset), 1, fp);
         fwrite(&nb_ptrs, sizeof(nb_ptrs), 1, fp);
@@ -1463,11 +1463,12 @@ void SaveCppExport(CppExport& cppexp, const char* filename)
     for (size_t i = 0; i < schemas.size(); i++)
     {
         const PtrSchema& s = *schemas[i];
-        fwrite(&s.ptr_offsets.front(), sizeof(size_t), s.ptr_offsets.size(), fp);
+        
+        fwrite(&(s.ptr_offsets.front()), sizeof(decltype(s.ptr_offsets)::value_type) * s.ptr_offsets.size(), 1, fp);
     }
 
     // Write the relocations
-    fwrite(&relocations.front(), sizeof(PtrRelocation), relocations.size(), fp);
+    fwrite(&(relocations.front()), sizeof(PtrRelocation) * relocations.size(), 1, fp);
 
     fclose(fp);
 }

--- a/src/clReflectExport/PtrRelocator.h
+++ b/src/clReflectExport/PtrRelocator.h
@@ -51,10 +51,10 @@ struct PtrSchema
     int handle;
 
     // Generally the type size
-    size_t stride;
+    clcpp::pointer_type stride;
 
     // Array of offsets within the type
-    std::vector<size_t> ptr_offsets;
+    std::vector<clcpp::pointer_type> ptr_offsets;
 };
 
 //
@@ -66,7 +66,7 @@ struct PtrRelocation
     int schema_handle;
 
     // Offset to add each pointer offset in the schema
-    size_t offset;
+    clcpp::pointer_type offset;
 
     // Number of objects to relocate, with object stride determined by the schema
     int nb_objects;


### PR DESCRIPTION
change some codes for successful build of x64 "clExport" and loading binaray file ( *.cppbin ) in x64

"clscan" and "clmerge" looks portable. Their outputs is exported well in x86 and x64.
So I didn't change anything in them.

But clExport was problem. When I build clexport build in x86 and read output of it, it made problems..
Problem was "**some codes store address to 4byte variable in x64!!**"

Actually, my codes looks not perfect. But It works well in x64.
