### PR TITLE
fix some codes for supporting clExport Build on x64

### DIFF
--- a/inc/clcpp/clcpp.h
+++ b/inc/clcpp/clcpp.h
@@ -196,7 +196,7 @@ namespace clcpp
 //
 // Placement new for the PtrWrapper logic specified above, which required matching delete
 //
-inline void* operator new(size_t size, const clcpp::internal::PtrWrapper& p)
+inline void* operator new(clcpp::size_type size, const clcpp::internal::PtrWrapper& p)
 {
     return (void*)&p;
 }

--- a/inc/clcpp/clcpp.h
+++ b/inc/clcpp/clcpp.h
@@ -196,7 +196,7 @@ namespace clcpp
 //
 // Placement new for the PtrWrapper logic specified above, which required matching delete
 //
-inline void* operator new(clcpp::size_type size, const clcpp::internal::PtrWrapper& p)
+inline void* operator new(size_t size, const clcpp::internal::PtrWrapper& p)
 {
     return (void*)&p;
 }

--- a/src/clReflectCore/Logging.cpp
+++ b/src/clReflectCore/Logging.cpp
@@ -18,8 +18,8 @@
 #include <map>
 
 
-#if defined(_MSC_VER)
-#include "immintrin.h"
+#if defined(_MSC_VER) && !defined(_M_IX86)
+    #include "immintrin.h"
 #endif
 
 namespace
@@ -213,10 +213,10 @@ namespace
 		{
 
 			v = sizeof(unsigned int) * 8 - 1
-#if defined(__GNUC__)  || defined( __clang__)
-				-__builtin_ia32_lzcnt_u32(v); // this require "-mlzcnt" compiler option
-#elif defined(_MSC_VER)
-				-_lzcnt_u32(v);
+#if defined(_MSC_VER) 
+				- _lzcnt_u32(v);
+#else
+                - __builtin_clz(v);
 #endif
 		}
 

--- a/src/clReflectCpp/clcpp.cpp
+++ b/src/clReflectCpp/clcpp.cpp
@@ -303,7 +303,7 @@ CLCPP_API void clcpp::internal::Assert(bool expression)
 {
     if (expression == false)
     {
-#ifdef CLCPP_USING_MSVC
+#if defined(CLCPP_USING_MSVC) && defined(_M_IX86)
         __asm
         {
             int 3h

--- a/src/clReflectCpp/clcpp.cpp
+++ b/src/clReflectCpp/clcpp.cpp
@@ -28,15 +28,15 @@ namespace
 {
     struct PtrSchema
     {
-        clcpp::size_type stride;
-        clcpp::size_type ptrs_offset;
-        clcpp::size_type nb_ptrs;
+        size_t stride;
+        size_t ptrs_offset;
+        size_t nb_ptrs;
     };
 
     struct PtrRelocation
     {
         int schema_handle;
-        clcpp::size_type offset;
+        size_t offset;
         int nb_objects;
     };
 
@@ -217,7 +217,7 @@ namespace
             return 0;
 
         // Read the pointer offsets for all the schemas
-        clcpp::CArray<clcpp::size_type> ptr_offsets;
+        clcpp::CArray<size_t> ptr_offsets;
         if (!ReadArray(file, ptr_offsets, file_header.nb_ptr_offsets, allocator))
             return 0;
 
@@ -233,20 +233,20 @@ namespace
             PtrSchema& schema = (PtrSchema&)schemas[reloc.schema_handle];
 
             // Take a weak C-array pointer to the schema's pointer offsets (for bounds checking)
-            clcpp::CArray<clcpp::size_type> schema_ptr_offsets;
-            schema_ptr_offsets.data = (clcpp::size_type*)&ptr_offsets[schema.ptrs_offset];
-            schema_ptr_offsets.size = schema.nb_ptrs;
+            clcpp::CArray<size_t> schema_ptr_offsets;
+            schema_ptr_offsets.data = (size_t*)&ptr_offsets[schema.ptrs_offset];
+            schema_ptr_offsets.size = static_cast<unsigned int>(schema.nb_ptrs);
 
             // Iterate over all objects in the instruction
             for (int j = 0; j < reloc.nb_objects; j++)
             {
-                clcpp::size_type object_offset = reloc.offset + j * schema.stride;
+                size_t object_offset = reloc.offset + static_cast<size_t>(j) * schema.stride;
 
                 // All pointers in the schema
-                for (clcpp::size_type k = 0; k < schema.nb_ptrs; k++)
+                for (size_t k = 0; k < schema.nb_ptrs; k++)
                 {
-                    clcpp::size_type ptr_offset = object_offset + schema_ptr_offsets[k];
-                    clcpp::size_type& ptr = (clcpp::size_type&)*(base_data + ptr_offset);
+                    size_t ptr_offset = object_offset + schema_ptr_offsets[k];
+                    size_t& ptr = (size_t&)*(base_data + ptr_offset);
 
                     // Ensure the pointer relocation is within range of the memory map before patching
                     clcpp::internal::Assert(ptr <= file_header.data_size);

--- a/src/clReflectCpp/clcpp.cpp
+++ b/src/clReflectCpp/clcpp.cpp
@@ -235,12 +235,12 @@ namespace
             // Take a weak C-array pointer to the schema's pointer offsets (for bounds checking)
             clcpp::CArray<size_t> schema_ptr_offsets;
             schema_ptr_offsets.data = (size_t*)&ptr_offsets[schema.ptrs_offset];
-            schema_ptr_offsets.size = static_cast<unsigned int>(schema.nb_ptrs);
+            schema_ptr_offsets.size = (unsigned int)schema.nb_ptrs;
 
             // Iterate over all objects in the instruction
             for (int j = 0; j < reloc.nb_objects; j++)
             {
-                size_t object_offset = reloc.offset + static_cast<size_t>(j) * schema.stride;
+                size_t object_offset = reloc.offset + (size_t)j * schema.stride;
 
                 // All pointers in the schema
                 for (size_t k = 0; k < schema.nb_ptrs; k++)

--- a/src/clReflectCpp/clcpp.cpp
+++ b/src/clReflectCpp/clcpp.cpp
@@ -303,7 +303,9 @@ CLCPP_API void clcpp::internal::Assert(bool expression)
 {
     if (expression == false)
     {
-#if defined(CLCPP_USING_MSVC) && defined(_M_IX86)
+#if defined(_M_IX86)
+
+#if defined(CLCPP_USING_MSVC)
         __asm
         {
             int 3h
@@ -311,6 +313,8 @@ CLCPP_API void clcpp::internal::Assert(bool expression)
 #else
         asm("int $0x3\n");
 #endif // CLCPP_USING_MSVC
+
+#endif
 
 // Leave the program with no continuation
 // Don't want people attaching the debugger and skipping over the break

--- a/src/clReflectScan/CMakeLists.txt
+++ b/src/clReflectScan/CMakeLists.txt
@@ -32,7 +32,6 @@ link_directories("${LLVM_BASE_LIB_DIR}")
 add_clreflect_executable(clReflectScan
   ASTConsumer.cpp
   AttributeParser.cpp
-  ClangFrontend.cpp
   Main.cpp
   ReflectionSpecs.cpp
   )


### PR DESCRIPTION
I'm sorry for my previous careless pull request.
I fixed it. I tried to touch codes as little as possible.

And inlined __asm codes can't be build on x64.
I don't know how to deal with it, So I didn't touch it.

